### PR TITLE
Feature/lcm spy cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repo contains some essential subpackages needed by all other MBot applications running off LCM:
 * [mbot_lcm_serial](mbot_lcm_serial): LCM-to-serial communication with the MBot control board.
 * [mbot_msgs](mbot_msgs): Message type definitions for LCM.
+* [mbot_lcm_spy](mbot_lcm_spy): Command line tool to monitor lcm messages similar to lcm-spy.
 
 ## Fast Install
 

--- a/mbot_lcm_spy/README.md
+++ b/mbot_lcm_spy/README.md
@@ -1,0 +1,56 @@
+> This is a command line tool works just like lcm-spy
+
+
+## Usage
+```shell
+mbot-lcm-spy [-h] [--channels CHANNELS] [--rate RATE] [--module MODULE]
+```
+
+### Options
+- `-h, --help`: Show this help message and exit
+- `--channels CHANNELS`: Comma-separated list of channel names to print decoded messages
+- `--rate RATE`: Rate at which data is printed in Hz (default: 1 Hz)
+- `--module MODULE`: Module to use for decoding messages (default: "mbot_lcm_msgs")
+
+For example, if you run:
+
+```shell
+mbot-lcm-spy --channels MBOT_ENCODERS,MBOT_IMU --rate 5
+```
+- Note that **DO NOT** put space between 2 channel names like this: `MBOT_ENCODERS, MBOT_IMU`
+
+You will get the output:
+
+
+#### Channel Information
+
+| Channel          | Type                | Rate  | Msgs Rcvd |
+| ---------------- | ------------------- | ----- | --------- |
+| MBOT\_ODOMETRY   | pose2D\_t           | 25.00 | 318       |
+| MBOT\_IMU        | mbot\_imu\_t        | 25.00 | 318       |
+| MBOT\_VEL        | twist2D\_t          | 25.00 | 318       |
+| MBOT\_MOTOR\_VEL | mbot\_motor\_vel\_t | 25.00 | 318       |
+| MBOT\_MOTOR\_PWM | mbot\_motor\_pwm\_t | 25.00 | 318       |
+| MBOT\_ENCODERS   | mbot\_encoders\_t   | 25.00 | 317       |
+| MBOT\_TIMESYNC   | timestamp\_t        | 1.00  | 13        |
+
+#### Decoded message on channel MBOT\_ENCODERS:
+
+| Field        | Value            |
+| ------------ | ---------------- |
+| utime        | 1718035974387383 |
+| ticks        | (-1, 276, 0)     |
+| delta\_ticks | (0, 0, 0)        |
+| delta\_time  | 40453            |
+
+#### Decoded message on channel MBOT\_IMU:
+
+| Field        | Value                               |
+| ------------ | ------------------------------------- |
+| utime        | 1718035974387383               |
+| gyro         | (0.002396918134763837, -0.0005326484679244459, 0.0017311074770987034)  |
+| accel        | (-0.7628380656242371, 0.6754170656204224, -10.061798095703125) |
+| mag          | (0.25, 0.25, 0.375) |
+| angles\_rpy  | (-0.06807039678096771, -0.07631554454565048, -0.12962138652801514)     |
+| angles\_quat | (0.99658203125, -0.03643798828125, -0.03594970703125, -0.064697265625) |
+| temp         | 0.0                                  |

--- a/mbot_lcm_spy/mbot_lcm_spy.py
+++ b/mbot_lcm_spy/mbot_lcm_spy.py
@@ -69,7 +69,7 @@ def truncate_array(value):
     try:
         # checks if the value is array-like and if its length > 10
         if hasattr(value, '__len__') and len(value) > 10:
-            return tuple(value[:10]) + ("...",)
+            return tuple(value[:8]) + ("...",)
     except TypeError:
         pass
         # otherwise return the original value
@@ -91,12 +91,11 @@ def decode_fields(decoded_msg):
                 else:
                     # Append the item directly if it doesn't have __slots__
                     nested_values.append(truncate_array(item))
-            fields.append((field, nested_values))
+            fields.append((field, truncate_array(nested_values)))
         elif hasattr(value, '__slots__'):
             # Recursively decode nested objects
             fields.append((field, decode_fields(value)))
         else:
-            # Truncate long arrays/lists if the value is an array-like data
             fields.append((field, truncate_array(value)))
     return fields
 

--- a/mbot_lcm_spy/mbot_lcm_spy.py
+++ b/mbot_lcm_spy/mbot_lcm_spy.py
@@ -69,7 +69,7 @@ def truncate_array(value):
     try:
         # checks if the value is array-like and if its length > 10
         if hasattr(value, '__len__') and len(value) > 10:
-            return tuple(value[:8]) + ("...",)
+            return tuple(value[:10]) + ("...",)
     except TypeError:
         pass
         # otherwise return the original value

--- a/mbot_lcm_spy/mbot_lcm_spy.py
+++ b/mbot_lcm_spy/mbot_lcm_spy.py
@@ -127,7 +127,7 @@ def print_status():
     while not stop_event.is_set():
         time.sleep(1 / args.rate)  # Update at the specified rate
         print("\033[H\033[J", end="")  # Clear the screen
-        print(f"{'Channel':<20} {'Type':<20} {'Rate':<10} {'Msgs Rcvd':<10}")
+        print(f"{'Channel':<20} {'Type':<22} {'Rate':<10} {'Msgs Rcvd':<10}")
         print("="*60)
         for channel, times in message_times.items():
             current_time = time.time()
@@ -137,7 +137,7 @@ def print_status():
             rate = len(times) / 1.0
             total_messages = message_counts[channel]
             lcm_type = channel_types.get(channel, "Unknown")
-            print(f"{channel:<20} {lcm_type:<20} {rate:<10.2f} {total_messages:<10}")
+            print(f"{channel:<20} {lcm_type:<22} {rate:<10.2f} {total_messages:<10}")
         
         for channel in channels_to_print:
             if channel in decoded_message_dict:

--- a/mbot_lcm_spy/nested_lcm_type_test.py
+++ b/mbot_lcm_spy/nested_lcm_type_test.py
@@ -1,0 +1,38 @@
+# Just to test if mbot-lcm-spy can take nested lcm struct
+
+import lcm
+import time
+from mbot_lcm_msgs.mbot_apriltag_array_t import mbot_apriltag_array_t
+from mbot_lcm_msgs.mbot_apriltag_t import mbot_apriltag_t
+
+lc = lcm.LCM("udpm://239.255.76.67:7667?ttl=0")
+
+msg = mbot_apriltag_array_t()
+msg.array_size = 2
+msg.detections = []
+
+apriltag1 = mbot_apriltag_t()
+apriltag1.tag_id = 1
+apriltag1.pose.x = 1
+apriltag1.pose.y = 2
+apriltag1.pose.z = 3
+apriltag1.pose.angles_rpy = [1.0, 2.1, 3.1]
+apriltag1.pose.angles_quat = [1, 2, 3, 4]
+msg.detections.append(apriltag1)
+
+apriltag2 = mbot_apriltag_t()
+apriltag2.tag_id = 2
+apriltag2.pose.x = 1
+apriltag2.pose.y = 2
+apriltag2.pose.z = 3
+apriltag2.pose.angles_rpy = [1.0, 2.1, 3.1]
+apriltag2.pose.angles_quat = [1, 2, 3, 4]
+msg.detections.append(apriltag2)
+
+try:
+    while True:
+        lc.publish("MBOT_APRILTAG_ARRAY", msg.encode())
+        time.sleep(0.1)
+except KeyboardInterrupt:
+    print("Exiting...")
+

--- a/mbot_lcm_spy_cli/lcm-spy-cli.py
+++ b/mbot_lcm_spy_cli/lcm-spy-cli.py
@@ -1,0 +1,124 @@
+import lcm
+import time
+from collections import defaultdict
+from threading import Thread, Event
+import argparse
+import importlib
+
+# Command-line argument parsing
+parser = argparse.ArgumentParser(description="LCM Spy CLI")
+parser.add_argument("--channels", type=str, help="Comma-separated list of channel names to print decoded messages")
+parser.add_argument("--rate", type=float, default=1, help="Rate at which data is printed in Hz (default: 1 Hz)")
+parser.add_argument("--module", type=str, help="Module to use for decoding messages")
+args = parser.parse_args()
+
+# Parse channels from the --channels argument
+channels_to_print = []
+if args.channels:
+    channels_to_print = args.channels.split(',')
+
+# Load the module for decoding messages if provided
+decode_module = None
+if args.module:
+    try:
+        decode_module = importlib.import_module(args.module)
+    except ImportError:
+        print(f"Error: Could not import module {args.module}")
+        decode_module = None
+
+# Data structures to hold message counts, timestamps, and LCM types
+message_counts = defaultdict(int)
+message_times = defaultdict(list)
+channel_types = {}
+stop_event = Event()
+decoded_message_dict = defaultdict(list)
+
+def message_handler(channel, data):
+    global message_counts, message_times, channel_types, decoded_message_dict
+    
+    msg_time = int(time.time())
+    
+    lcm_type = "Unknown"
+    decoded_message = None
+    if decode_module:
+        try:
+            # Attempt to decode the message to find its type
+            for attr in dir(decode_module):
+                lcm_type_class = getattr(decode_module, attr)
+                if isinstance(lcm_type_class, type) and hasattr(lcm_type_class, 'decode'):
+                    try:
+                        lcm_type_instance = lcm_type_class.decode(data)
+                        lcm_type = lcm_type_class.__name__
+                        decoded_message = lcm_type_instance
+                        break
+                    except Exception:
+                        continue
+        except Exception as e:
+            lcm_type = f"Error: {e}"
+
+    # Store the decoded message fields if the channel matches any of the specified channels
+    if channel in channels_to_print and decoded_message:
+        decoded_message_dict[channel] = [(field, getattr(decoded_message, field)) for field in decoded_message.__slots__]
+    
+    # Update message counts and times
+    message_counts[channel] += 1
+    message_times[channel].append(time.time())
+    channel_types[channel] = lcm_type
+
+def print_status():
+    while not stop_event.is_set():
+        time.sleep(1 / args.rate)  # Update at the specified rate
+        print("\033[H\033[J", end="")  # Clear the screen
+        print(f"{'Channel':<20} {'Type':<20} {'Rate':<10} {'Msgs Rcvd':<10}")
+        print("="*60)
+        for channel, times in message_times.items():
+            current_time = time.time()
+            # Filter times to keep only those within the last second
+            times = [t for t in times if current_time - t < 1]
+            message_times[channel] = times
+            rate = len(times) / 1.0
+            total_messages = message_counts[channel]
+            lcm_type = channel_types.get(channel, "Unknown")
+            print(f"{channel:<20} {lcm_type:<20} {rate:<10.2f} {total_messages:<10}")
+        
+        for channel in channels_to_print:
+            if channel in decoded_message_dict:
+                print(f"\nDecoded message on channel {channel}:")
+                print(f"{'Field':<20} {'Value':<20}")
+                print("="*40)
+                for field, value in decoded_message_dict[channel]:
+                    print(f"{field:<20} {str(value):<20}")
+
+def lcm_handle_loop(lc):
+    while not stop_event.is_set():
+        try:
+            lc.handle_timeout(1000)  # Timeout set to 1000ms
+        except Exception as e:
+            print(f"Error in LCM handle loop: {e}")
+
+if __name__ == "__main__":
+    lc = lcm.LCM()
+
+    # Subscribe to all LCM channels
+    subscription = lc.subscribe(".*", message_handler)
+
+    # Start the status printing thread
+    status_thread = Thread(target=print_status)
+    status_thread.daemon = True
+    status_thread.start()
+
+    # Start the LCM handle loop
+    lcm_thread = Thread(target=lcm_handle_loop, args=(lc,))
+    lcm_thread.daemon = True
+    lcm_thread.start()
+    
+    try:
+        while True:
+            time.sleep(1)  # Main thread sleep
+    except KeyboardInterrupt:
+        print("\nExiting gracefully...")
+        stop_event.set()
+        lcm_thread.join()
+        status_thread.join()
+        lc.unsubscribe(subscription)
+        print("Exited cleanly.")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -13,6 +13,11 @@ make
 sudo make install
 cd ..
 
+# Install mbot-lcm-spy
+echo "Installing mbot-lcm-spy..."
+chmod +x mbot_lcm_spy/mbot_lcm_spy.py
+sudo cp mbot_lcm_spy/mbot_lcm_spy.py /usr/local/bin/mbot-lcm-spy
+
 # Install the serial service.
 LCM_SERIAL_SRV_PATH=mbot_lcm_serial/services/
 LCM_SERIAL_SRV_NAME=mbot-lcm-serial.service


### PR DESCRIPTION
### What's new:

1. Added mbot-lcm-spy tool, a command line tool works like lcm-spy
2. Updated install script, `mbot-lcm-spy` is now avaibale system-wise
3. Added new README for `mbot-lcm-spy` with instruction
4. Modified `mbot_lcm_spy.py`, now if any array-like values have length > 10, the rest will be cut off

    Decoded message on channel LIDAR:

    | Field       | Value                                                                 |
    |-------------|-----------------------------------------------------------------------|
    | utime       | 1718406870227488                                                      |
    | num_ranges  | 275                                                                   |
    | ranges      | (0.7879999876022339, 0.8119999766349792, 0.8399999737739563, 0.8700000047683716, 0.9020000100135803, 0.9399999976158142, 0.9779999852180481, 0.0, 0.7519999742507935, 0.7400000095367432, '...') |
    | thetas      | (0.0038349521346390247, 0.02761165425181389, 0.051292482763528824, 0.07506918907165527, 0.09875001758337021, 0.12358132749795914, 0.14754977822303772, 0.16816264390945435, 0.18628279864788055, 0.20814202725887299, '...') |
    | times       | (1718406870080127, 1718406870080260, 1718406870080393, 1718406870080526, 1718406870080659, 1718406870080792, 1718406870080925, 1718406870081058, 1718406870081191, 1718406870081324, '...') |
    | intensities | (47.0, 47.0, 47.0, 47.0, 47.0, 47.0, 47.0, 0.0, 47.0, 47.0, '...') |

5. Nested lcm data structure is supported, such as mbot_apriltag       