### PR TITLE
added new message for mbot cone detection

### DIFF
--- a/mbot_msgs/CMakeLists.txt
+++ b/mbot_msgs/CMakeLists.txt
@@ -44,6 +44,8 @@ set(LCM_FILES
       lcmtypes/planner_request_t.lcm
       lcmtypes/mbot_apriltag_t.lcm
       lcmtypes/mbot_apriltag_array_t.lcm
+      lcmtypes/mbot_cone_t.lcm
+      lcmtypes/mbot_cone_array_t.lcm
 )
 
 lcm_wrap_types(

--- a/mbot_msgs/lcmtypes/mbot_cone_array_t.lcm
+++ b/mbot_msgs/lcmtypes/mbot_cone_array_t.lcm
@@ -1,0 +1,8 @@
+package mbot_lcm_msgs;
+
+struct mbot_cone_array_t
+{
+    int64_t utime;
+    int32_t array_size;
+    mbot_cone_t detections[array_size];
+}

--- a/mbot_msgs/lcmtypes/mbot_cone_t.lcm
+++ b/mbot_msgs/lcmtypes/mbot_cone_t.lcm
@@ -1,0 +1,7 @@
+package mbot_lcm_msgs;
+
+struct mbot_cone_t
+{
+    string name;
+    pose3D_t pose;
+}


### PR DESCRIPTION
New LCM message type added as discussed, to support cone detection in mbot_vision. Tested.